### PR TITLE
Always require email when updating a member

### DIFF
--- a/members-service/request-schemas.js
+++ b/members-service/request-schemas.js
@@ -18,7 +18,7 @@ export const SHOW_MEMBER_SCHEMA = {
 
 export const UPDATE_MEMBER_SCHEMA = {
   type: 'object',
-  required: ['id'],
+  required: ['id', 'email'],
   properties: {
     id: { type: 'string', pattern: '^[0-9]+$' },
     email: { type: 'string', format: 'email' },


### PR DESCRIPTION
Champaign needs an email, whilst AK needs an id. Require both and make
life easy.