### PR TITLE
Revert "Always require `email` when updating a member"

### DIFF
--- a/members-service/request-schemas.js
+++ b/members-service/request-schemas.js
@@ -18,7 +18,7 @@ export const SHOW_MEMBER_SCHEMA = {
 
 export const UPDATE_MEMBER_SCHEMA = {
   type: 'object',
-  required: ['id', 'email'],
+  required: ['id'],
   properties: {
     id: { type: 'string', pattern: '^[0-9]+$' },
     email: { type: 'string', format: 'email' },


### PR DESCRIPTION
This reverts commit 94906a12afa69df6a207581020bbad5890faeae1.  We're disabling email updates temporarily (in the frontend) so the email parameter requirement is now invalid.